### PR TITLE
fix: unblock truncated QC aggregation with v12

### DIFF
--- a/.codeocean/nextflow.json
+++ b/.codeocean/nextflow.json
@@ -330,7 +330,7 @@
 				"id": "4a698b5c-f5f6-4671-8234-dc728d049a68",
 				"name": "aind-ophys-quality-control-aggregator",
 				"slug": "4044810",
-				"version": 10,
+				"version": 12,
 				"arguments": [
 					"--image_type=\"multiplane\""
 				],
@@ -363,14 +363,6 @@
 					"type": "dataset",
 					"name": "multiplane-ophys-test-asset_results",
 					"source_path": "multiplane-ophys-test-asset_results/*/decrosstalk/*.json",
-					"collect": true
-				},
-				{
-					"id": "1NW4IkpwVsdV6hdv",
-					"source_id": "2cd3cc54-0f19-452e-8ddf-ddb28ece106c",
-					"type": "dataset",
-					"name": "multiplane-ophys-test-asset_results",
-					"source_path": "multiplane-ophys-test-asset_results/*/decrosstalk/*.png",
 					"collect": true
 				},
 				{

--- a/pipeline/main.nf
+++ b/pipeline/main.nf
@@ -31,7 +31,6 @@ capsule_aind_ophys_extraction_4_to_capsule_aind_ophys_classifier_11_22 = channel
 multiplane_ophys_test_asset_results_to_aind_ophys_quality_control_aggregator_23 = channel.fromPath(params.multiplane_ophys_test_asset_results_url + "/*/motion_correction/*.json", type: 'any')
 multiplane_ophys_test_asset_results_to_aind_ophys_quality_control_aggregator_24 = channel.fromPath(params.multiplane_ophys_test_asset_results_url + "/*/movie_qc/*.json", type: 'any')
 multiplane_ophys_test_asset_results_to_aind_ophys_quality_control_aggregator_25 = channel.fromPath(params.multiplane_ophys_test_asset_results_url + "/*/decrosstalk/*.json", type: 'any')
-multiplane_ophys_test_asset_results_to_aind_ophys_quality_control_aggregator_26 = channel.fromPath(params.multiplane_ophys_test_asset_results_url + "/*/decrosstalk/*.png", type: 'any')
 capsule_aind_ophys_classifier_11_to_capsule_aind_ophys_quality_control_aggregator_12_27 = channel.create()
 capsule_aind_ophys_classifier_11_to_capsule_aind_ophys_quality_control_aggregator_12_28 = channel.create()
 capsule_aind_ophys_extraction_4_to_capsule_aind_ophys_quality_control_aggregator_12_29 = channel.create()
@@ -371,7 +370,7 @@ process capsule_aind_ophys_classifier_11 {
 // capsule - aind-ophys-quality-control-aggregator
 process capsule_aind_ophys_quality_control_aggregator_12 {
 	tag 'capsule-4044810'
-	container "$REGISTRY_HOST/published/4a698b5c-f5f6-4671-8234-dc728d049a68:v10"
+	container "$REGISTRY_HOST/published/4a698b5c-f5f6-4671-8234-dc728d049a68:v12"
 
 	cpus 1
 	memory '7.5 GB'
@@ -382,7 +381,6 @@ process capsule_aind_ophys_quality_control_aggregator_12 {
 	path 'capsule/data/' from multiplane_ophys_test_asset_results_to_aind_ophys_quality_control_aggregator_23.collect()
 	path 'capsule/data/' from multiplane_ophys_test_asset_results_to_aind_ophys_quality_control_aggregator_24.collect()
 	path 'capsule/data/' from multiplane_ophys_test_asset_results_to_aind_ophys_quality_control_aggregator_25.collect()
-	path 'capsule/data/' from multiplane_ophys_test_asset_results_to_aind_ophys_quality_control_aggregator_26.collect()
 	path 'capsule/data/' from capsule_aind_ophys_classifier_11_to_capsule_aind_ophys_quality_control_aggregator_12_27.collect()
 	path 'capsule/data/' from capsule_aind_ophys_classifier_11_to_capsule_aind_ophys_quality_control_aggregator_12_28.collect()
 	path 'capsule/data/' from capsule_aind_ophys_extraction_4_to_capsule_aind_ophys_quality_control_aggregator_12_29.collect()
@@ -410,9 +408,9 @@ process capsule_aind_ophys_quality_control_aggregator_12 {
 
 	echo "[${task.tag}] cloning git repo..."
 	if [[ "\$(printf '%s\n' "2.20.0" "\$(git version | awk '{print \$3}')" | sort -V | head -n1)" = "2.20.0" ]]; then
-		git -c credential.helper= clone --filter=tree:0 --branch v10.0 "https://\$GIT_ACCESS_TOKEN@\$GIT_HOST/capsule-4044810.git" capsule-repo
+		git -c credential.helper= clone --filter=tree:0 --branch v12.0 "https://\$GIT_ACCESS_TOKEN@\$GIT_HOST/capsule-4044810.git" capsule-repo
 	else
-		git -c credential.helper= clone --branch v10.0 "https://\$GIT_ACCESS_TOKEN@\$GIT_HOST/capsule-4044810.git" capsule-repo
+		git -c credential.helper= clone --branch v12.0 "https://\$GIT_ACCESS_TOKEN@\$GIT_HOST/capsule-4044810.git" capsule-repo
 	fi
 	mv capsule-repo/code capsule/code && ln -s \$PWD/capsule/code /code
 	rm -rf capsule-repo


### PR DESCRIPTION
- Pins the quality-control aggregator to released v12.
- Removes the optional decrosstalk PNG input that prevents the aggregator from scheduling when older prior assets contain no previews.
- Brings the linked QC changes from [PR #22](https://github.com/AllenNeuralDynamics/aind-ophys-quality-control-aggregator/pull/22) and [PR #27](https://github.com/AllenNeuralDynamics/aind-ophys-quality-control-aggregator/pull/27) into the truncated pipeline to unblock 46 of 570 reprocessing assets.